### PR TITLE
TOOLS: Add commit message checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Welcome to **CppSampleProject**, the C++ sample project!
 
-This is a **C++** sample project which presents a base project structure which is ideal to develop many projects in parallel. The dependencies are organized into one common place in order to avoid its unnecessary downloading and building. It contains templates to create libraries and applications (executable programs) as well. It uses [**CMake**](https://cmake.org/), [**Git**](https://git-scm.com/), [**GitHub**](https://github.com/), [**Google Test**](https://github.com/google/googletest) and [**Markdown**](https://www.markdownguide.org/).
+This is a **C++** sample project which presents a base project structure which is ideal to develop many projects in parallel. The dependencies are organized into one common place in order to avoid its unnecessary downloading and building. It contains templates to create libraries and applications (executable programs) as well. It uses [**CMake**](https://cmake.org/), [**Git**](https://git-scm.com/), [**GitHub**](https://github.com/), [**Google Test**](https://github.com/google/googletest), [**Markdown**](https://www.markdownguide.org/) and **Bash** and **Batch** scripts.
 
 ### **Structure of the project:**
 ```
@@ -26,6 +26,7 @@ ProgrammingRepo
                 AppTestCases.cpp
                 LibTestCases.cpp
                 CMakeLists.txt
+            tools
             CMakeLists.txt
 ```
 - **ProgrammingRepo `*`**  
@@ -56,6 +57,9 @@ ProgrammingRepo
 
 - **test**  
     It is a folder to store the test related header and source files.
+
+- **tools**  
+    It is a folder to store the tools and scripts.
 
 `*` ***Please note*** that the folders - marked with `*` - are not part of this **Git** repository!  
 The **ProgrammingRepo** and **Projects** folders are [*prerequisites*](#prerequisites).  
@@ -91,12 +95,22 @@ Move into the **ProgrammingRepo** folder and run:
 ```
 cd Projects
 git clone https://github.com/slali87/CppSampleProject.git
+cd CppSampleProject
+```
+
+### **Set up the project:**
+Move into the **CppSampleProject** folder and run:
+```
+./setup.sh   #on Linux
+```
+or
+```
+./setup.bat   #on Windows
 ```
 
 ### **Steps of build:**
-Move into the **Projects** folder and run:
+Move into the **CppSampleProject** folder and run:
 ```
-cd CppSampleProject
 cmake -B build   # Specify the CMake generator if the default is not right!
 cd build
 cmake --build .

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,21 @@
+@echo off
+echo Setup by Batch Script
+
+rem create a temporary batch file in order to the call function can run it
+copy .\tools\setup\setup_common .\tools\setup\setup_common.bat
+call .\tools\setup\setup_common.bat
+set /a error = %errorlevel%
+del .\tools\setup\setup_common.bat
+if %error%==0 (if %errorlevel% NEQ 0 (
+    set /a error = %errorlevel%
+))
+
+echo.
+echo ==============================
+if %error%==0 (
+    echo Setup successfully finished!
+) else (
+    echo Error: %error%
+    echo Setup failed!!!
+)
+echo ==============================

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+echo "Setup by Bash Shell Script"
+
+source ./tools/setup/setup_common
+error=$?
+
+echo
+echo "=============================="
+if [ $error -eq 0 ]; then
+   echo "Setup successfully finished!"
+else
+   echo "Setup failed!!!"
+fi
+echo "=============================="

--- a/tools/git/hooks/commit-msg
+++ b/tools/git/hooks/commit-msg
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Check if the header is not too long.
+HEADER=$(head -n 1 "$1")
+MAX_HEADER_LEN=50
+if [ ${#HEADER} -gt $MAX_HEADER_LEN ]; then
+    echo "Header of the commit message is longer than $MAX_HEADER_LEN characters!!!"
+    exit 1
+fi
+
+# Check if the header is valid.
+PATTERN="^(FEAT|FIX|IMPR|TEST|TOOLS|DOCS): (.*)$"
+if ! echo "$HEADER" | grep -Eq "$PATTERN"; then
+    echo "Header of the commit message is invalid!!!"
+    echo "   $HEADER"
+    echo "Use the following format:"
+    echo "   TAG: Header message"
+    echo "The TAG must be one from the following list (the list is ordered by priority):"
+    echo "   FEAT: to add new feature to product code"
+    echo "   FIX: to fix a bug in product code"
+    echo "   IMPR: to improve, refactor, rewrite the product code"
+    echo "   TEST: to add test related changes"
+    echo "   TOOLS: to add tools related changes"
+    echo "   DOCS: to add documentation related changes"
+    echo "For example:" 
+    echo "   TOOLS: Add commit message checker"
+    exit 2
+fi
+
+# Check if there is at least 3 lines.
+LINE_NUM=$(wc -l "$1" | awk '{print $1}')
+if [ $LINE_NUM -lt 3 ]; then
+    echo "At least 3 lines (including the header and the empty second lines) needed!!!"
+    exit 3
+fi
+
+# Check if the second line is empty.
+LINE2=$(head -n 2 "$1" | tail -1)
+if ! [ "$LINE2" = "" ]; then
+    echo "The second line of the commit message is not empty!!!"
+    exit 4
+fi
+
+# Check if the third line is not empty.
+LINE3=$(head -n 3 "$1" | tail -2)
+if [ "$LINE3" = "" ]; then
+    echo "The third line of the commit message is empty!!!"
+    exit 5
+fi
+
+# Check if commit message lines are not too long.
+MAX_LINE_LEN=72
+while read LINE; do
+    if [ ${#LINE} -gt $MAX_LINE_LEN ]; then
+        echo "Commit messages are limited to $MAX_LINE_LEN characters."
+        echo "The following commit message has ${#LINE} characters!!!"
+        echo "$LINE"
+        exit 6
+    fi
+done < "$1"
+
+exit 0

--- a/tools/git/hooks/test_commit-msg
+++ b/tools/git/hooks/test_commit-msg
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+testCommitMessageChecker () {
+    echo "$1" > ./tmp
+    ./commit-msg ./tmp
+    error=$?
+    rm ./tmp
+    if [ $error -ne $2 ]; then
+        echo "Test failed!!!"
+        exit 1
+    fi
+}
+
+# Checker fails when header is too long.
+testCommitMessageChecker $'HeaderHeaderHeaderHeaderHeaderHeaderHeaderHeaderHeader\n\n' 1
+
+# Checker fails when header is invalid.
+testCommitMessageChecker $'Header\n\n' 2
+
+# Checker fails when there is no enough lines.
+testCommitMessageChecker $'FEAT: First' 3
+
+# Checker fails when there is no enough lines.
+testCommitMessageChecker $'FEAT: First\n' 3
+
+# Checker fails when second line is not empty.
+testCommitMessageChecker $'FEAT: First\nSecond\nThird\n\n' 4
+
+# Checker fails when third line is empty.
+testCommitMessageChecker $'FEAT: First\n\n' 5
+
+# Checker fails when third line is empty.
+testCommitMessageChecker $'FEAT: First\n\n\n' 5
+
+# Checker fails when a line is too long.
+testCommitMessageChecker $'FEAT: First\n\nThirdThirdThirdThirdThirdThirdThirdThirdThirdThirdThirdThirdThirdThirdThird' 6
+
+# Checker passes.
+testCommitMessageChecker $'FEAT: First\n\nThird' 0
+
+echo "=============================="
+echo "Tests successfully finished!"
+echo "=============================="
+
+exit 0

--- a/tools/setup/setup_common
+++ b/tools/setup/setup_common
@@ -1,0 +1,2 @@
+echo "Common Setup part"
+git config core.hooksPath ./tools/git/hooks


### PR DESCRIPTION
Create 'commit-msg' git hook to check the commit message.
Setup.bat and setup.sh are created to move the 'commit-msg' to the
 .git/hooks directory. They have to be called after the cloning.
The 'test_commit-msg' contains tests to verify the checker.