### PR TITLE
FIX: Change to static linking of GTest

### DIFF
--- a/.github/workflows/CppSampleProjectCI.yml
+++ b/.github/workflows/CppSampleProjectCI.yml
@@ -66,4 +66,4 @@ jobs:
           cd Projects/CppSampleProject/build
           src/CppSampleProject
           test/CppSampleProjectTest
-          #ctest
+          ctest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,6 @@ find_library(GTest gtest HINTS ${CMAKE_CURRENT_SOURCE_DIR}/../../../Deps/googlet
 if(UNIX)
   set(PThreadLib -pthread)
 endif()
-target_link_libraries(${CMAKE_PROJECT_NAME}Test PUBLIC ${CMAKE_PROJECT_NAME}Lib ${CMAKE_PROJECT_NAME}InnerLib ${PThreadLib} ${GTest})
+target_link_libraries(${CMAKE_PROJECT_NAME}Test -static ${CMAKE_PROJECT_NAME}Lib ${CMAKE_PROJECT_NAME}InnerLib ${PThreadLib} ${GTest})
 
 add_test(NAME ${CMAKE_PROJECT_NAME}Test COMMAND ${CMAKE_PROJECT_NAME}Test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,9 @@ add_executable (${CMAKE_PROJECT_NAME}Test main.cpp LibTestCases.cpp AppTestCases
 find_library(GTest gtest HINTS ${CMAKE_CURRENT_SOURCE_DIR}/../../../Deps/googletest/build/lib/)
 if(UNIX)
   set(PThreadLib -pthread)
+else()
+  set(StaticLink -static)
 endif()
-target_link_libraries(${CMAKE_PROJECT_NAME}Test -static ${CMAKE_PROJECT_NAME}Lib ${CMAKE_PROJECT_NAME}InnerLib ${PThreadLib} ${GTest})
+target_link_libraries(${CMAKE_PROJECT_NAME}Test PUBLIC ${CMAKE_PROJECT_NAME}Lib ${CMAKE_PROJECT_NAME}InnerLib ${PThreadLib} ${StaticLink} ${GTest})
 
 add_test(NAME ${CMAKE_PROJECT_NAME}Test COMMAND ${CMAKE_PROJECT_NAME}Test)


### PR DESCRIPTION
Change to static linking to fix linking of GTest on Windows.
Comment back running of ctest.

This change fixes the issue was observed at run #6.