### PR TITLE
TOOLS: Fix CI file to use name & password at push

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -127,7 +127,6 @@ jobs:
           git config user.email "githubaction@users.noreply.github.com"
           git config user.name "GitHub Action"
           git config credential.username ${{ github.actor }}
-          git config credential.password ${{ secrets.GITHUB_TOKEN }}
           rm -rf Doc CodeCoverage
           mv ../Doc/html Doc
           mv ../TestCov/CodeCoverage CodeCoverage

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,7 +105,7 @@ jobs:
           retention-days: 1
   UploadToGHpages:
     name: UploadToGHpages
-    if: success() #&& github.ref == 'refs/heads/main'   # Upload only from main
+    if: success() && github.ref == 'refs/heads/main'   # Upload only from main
     needs: [Verification]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -127,7 +127,7 @@ jobs:
           git config user.email "githubaction@users.noreply.github.com"
           git config user.name "GitHub Action"
           git config credential.username ${{ github.actor }}
-          git config credential.password ${{ github.token }}
+          git config credential.password ${{ secrets.GITHUB_TOKEN }}
           rm -rf Doc CodeCoverage
           mv ../Doc/html Doc
           mv ../TestCov/CodeCoverage CodeCoverage

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -132,4 +132,4 @@ jobs:
           mv ../TestCov/CodeCoverage CodeCoverage
           git add Doc/ CodeCoverage/
           git commit --amend -m "Upload from ${{ github.sha }}" # Overwrite since the history is not needed for generated files
-          git push --force
+          git push --force https://${{ github.token }}@github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}.git

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -132,4 +132,4 @@ jobs:
           mv ../TestCov/CodeCoverage CodeCoverage
           git add Doc/ CodeCoverage/
           git commit --amend -m "Upload from ${{ github.sha }}" # Overwrite since the history is not needed for generated files
-          git push --force https://${{ github.token }}@github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}.git
+          git push --force https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}.git

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,7 +105,7 @@ jobs:
           retention-days: 1
   UploadToGHpages:
     name: UploadToGHpages
-    if: success() && github.ref == 'refs/heads/main'   # Upload only from main
+    if: success() #&& github.ref == 'refs/heads/main'   # Upload only from main
     needs: [Verification]
     runs-on: ubuntu-latest
     strategy:
@@ -126,6 +126,8 @@ jobs:
           cd ${{ github.event.repository.name }}
           git config user.email "githubaction@users.noreply.github.com"
           git config user.name "GitHub Action"
+          git config credential.username ${{ github.actor }}
+          git config credential.password ${{ github.token }}
           rm -rf Doc CodeCoverage
           mv ../Doc/html Doc
           mv ../TestCov/CodeCoverage CodeCoverage


### PR DESCRIPTION
Fix the CI file to use the username and password at push.